### PR TITLE
Use Partials

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,5 @@
+<nav class="navbar navbar-default navbar-fixed-top">
+  <div class="navbar-brand">
+    Programmers We L<span class="glyphicon glyphicon-heart"></span>ve
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,26 +1,16 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>RailsProgrammerProfilePartials</title>
-  <%= stylesheet_link_tag    'application', media: 'all' %>
-  <%= javascript_include_tag 'application' %>
-  <%= csrf_meta_tags %>
-  <%= analytics_init if Rails.env.production? %>
-</head>
-<body>
-
-
-<div class="container">
-
-  <nav class="navbar navbar-default navbar-fixed-top">
-    <div class="navbar-brand">
-      Programmers We L<span class="glyphicon glyphicon-heart"></span>ve
+  <head>
+    <title>RailsProgrammerProfilePartials</title>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
+    <%= csrf_meta_tags %>
+    <%= analytics_init if Rails.env.production? %>
+  </head>
+  <body>
+    <div class="container">
+      <%= render 'layouts/navbar' %>
+      <%= yield %>
     </div>
-  </nav>
-
-  <%= yield %>
-
-</div>
-
-</body>
+  </body>
 </html>

--- a/app/views/programmers/_programmer.html.erb
+++ b/app/views/programmers/_programmer.html.erb
@@ -1,0 +1,6 @@
+<%= link_to programmer_path(programmer) do %>
+  <p class="list-group-item programmer-item">
+    <%= image_tag programmer.image, width: '70px' %>
+    <%= programmer.name %>
+  </p>
+<% end %>

--- a/app/views/programmers/index.html.erb
+++ b/app/views/programmers/index.html.erb
@@ -1,12 +1,6 @@
 <h1>Our Favorite Programmers</h1>
 
 <ul class="list-group">
-<% @programmers.each do |programmer| %>
-  <%= link_to programmer_path(programmer) do %>
-  <p class="list-group-item programmer-item">
-    <%= image_tag programmer.image, width: '70px' %>
-    <%= programmer.name %>
-  </p>
-  <% end %>
-<% end %>
+<%= render @programmers %>
+
 </ul>


### PR DESCRIPTION
This pull request refactors the way the navbar and programmer list are rendered to improve code organization and reusability. The navbar is moved to a partial, and the programmer list uses a partial for each programmer, simplifying the main index view.

**Navbar refactoring:**
* Created a new partial `_navbar.html.erb` for the navbar and updated the layout to render this partial instead of inline HTML. [[1]](diffhunk://#diff-ecb32a9b0d6ec13e981a5b858b462c5c20f35f5d66df3a41955f82dd731e1148R1-R5) [[2]](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebL11-L24)

**Programmer list refactoring:**
* Created a new partial `_programmer.html.erb` for rendering individual programmers and updated `index.html.erb` to use this partial with `render @programmers`. [[1]](diffhunk://#diff-697c327702a4fd07b7c7aebb68812a5487fe3c16c2e3c1742e9a691f9ffc8f8cR1-R6) [[2]](diffhunk://#diff-e3c9da879b24b70289531fbfcfbabeda771468fd287ef151e7cb984c6cd82a59L4-R5)